### PR TITLE
Improve decompilation tests

### DIFF
--- a/derived-artifacts/compiled.cmake
+++ b/derived-artifacts/compiled.cmake
@@ -26,7 +26,7 @@ set(CFLAGS_static_native ${CFLAGS_dynamic_native} -static)
 set(CFLAGS_CATEGORY_tests_analysis -nostdlib -O2 -fno-stack-protector -fomit-frame-pointer -fno-reorder-functions -fno-unwind-tables -fno-asynchronous-unwind-tables -fno-stack-check -fno-optimize-sibling-calls -fno-inline-functions -fno-inline-small-functions -fno-align-functions -fno-optimize-sibling-calls)
 set(CFLAGS_CATEGORY_tests_analysis_StackAnalysis -nostdlib)
 set(CFLAGS_CATEGORY_tests_runtime -std=c99 -fno-pic -fno-pie -ggdb3 -fno-stack-protector)
-set(CFLAGS_CATEGORY_tests_analysis_Decompilation -fno-inline)
+set(CFLAGS_CATEGORY_tests_analysis_Decompilation -fno-inline -O2)
 set(CFLAGS_CATEGORY_tests_analysis_PromoteStackPointer -no-pie -fno-unroll-loops -fno-inline -O1 -fno-stack-protector)
 
 macro(artifact_handler CATEGORY INPUT_FILE CONFIGURATION OUTPUT TARGET_NAME)

--- a/tests/analysis/Decompilation/dynamic_native/array.c
+++ b/tests/analysis/Decompilation/dynamic_native/array.c
@@ -9,7 +9,7 @@ typedef struct __attribute__((packed)) {
   uint64_t uint64;
 } TestStruct;
 
-TestStruct global_struct;
+static TestStruct global_struct = {0};
 
 static TestStruct *getGlobalStruct(void) {
   return &global_struct;

--- a/tests/analysis/Decompilation/dynamic_native/array_of_structs.c
+++ b/tests/analysis/Decompilation/dynamic_native/array_of_structs.c
@@ -10,7 +10,7 @@ typedef struct __attribute__((packed)) {
   uint64_t second_uint64;
 } TestStruct;
 
-TestStruct global_struct[10];
+static TestStruct global_struct[10] = {0};
 
 static TestStruct *getGlobalStructArray(void) {
   return global_struct;

--- a/tests/analysis/Decompilation/dynamic_native/linked_list.c
+++ b/tests/analysis/Decompilation/dynamic_native/linked_list.c
@@ -23,31 +23,43 @@ int getNext(struct Node *n) {
   return 0;
 }
 
+uint32_t getContent(struct Node *n) {
+  return n ? n->content_uint32 : 0U;
+}
+
+void initNode(struct Node *n) {
+  if (!n)
+    return;
+  n->prev = NULL;
+  n->next = NULL;
+  n->content_uint32 = 0U;
+}
+
 static struct Node Nodes[11] = {0};
 
 static struct Node* getGlobalNodes() {
   return &Nodes[0];
 }
 
-
 int main(int argc, char **argv) {
   struct Node *first = getGlobalNodes();
-  first->prev = NULL;
+  initNode(first);
 
   struct Node *cur = first;
   for (int i = 0; i < 10; i++) {
     struct Node *new_node = first + i + 1;
+    initNode(new_node);
+    new_node->content_uint32 = i;
+    new_node->prev = cur;
 
     cur->next = new_node;
-    new_node->prev = cur;
-    new_node->next = NULL;
-    new_node->content_uint32 = i;
-    cur = cur->next;
+    cur = new_node;
   }
 
   int sum = 0;
   cur = first;
   while (cur) {
+    sum += getContent(cur);
     sum += getPrevious(cur);
     sum += getNext(cur);
     cur = cur->next;

--- a/tests/analysis/Decompilation/dynamic_native/linked_list.c
+++ b/tests/analysis/Decompilation/dynamic_native/linked_list.c
@@ -16,19 +16,28 @@ int getPrevious(struct Node *n) {
     return n->prev->content_uint32;
   return 0;
 }
+
 int getNext(struct Node *n) {
   if (n->next)
     return n->next->content_uint32;
   return 0;
 }
 
-int main() {
-  struct Node *first = (struct Node *) malloc(sizeof(struct Node));
+static struct Node Nodes[11] = {0};
+
+static struct Node* getGlobalNodes() {
+  return &Nodes[0];
+}
+
+
+int main(int argc, char **argv) {
+  struct Node *first = getGlobalNodes();
   first->prev = NULL;
 
   struct Node *cur = first;
   for (int i = 0; i < 10; i++) {
-    struct Node *new_node = (struct Node *) malloc(sizeof(struct Node));
+    struct Node *new_node = first + i + 1;
+
     cur->next = new_node;
     new_node->prev = cur;
     new_node->next = NULL;

--- a/tests/analysis/Decompilation/dynamic_native/linked_list.c
+++ b/tests/analysis/Decompilation/dynamic_native/linked_list.c
@@ -11,23 +11,23 @@ struct __attribute__((packed)) Node {
   struct Node *next;
 };
 
-int getPrevious(struct Node *n) {
+static int getPrevious(struct Node *n) {
   if (n->prev)
     return n->prev->content_uint32;
   return 0;
 }
 
-int getNext(struct Node *n) {
+static int getNext(struct Node *n) {
   if (n->next)
     return n->next->content_uint32;
   return 0;
 }
 
-uint32_t getContent(struct Node *n) {
+static uint32_t getContent(struct Node *n) {
   return n ? n->content_uint32 : 0U;
 }
 
-void initNode(struct Node *n) {
+static void initNode(struct Node *n) {
   if (!n)
     return;
   n->prev = NULL;

--- a/tests/analysis/Decompilation/dynamic_native/struct.c
+++ b/tests/analysis/Decompilation/dynamic_native/struct.c
@@ -9,7 +9,7 @@ typedef struct __attribute__((packed)) {
   uint32_t second_uint32;
 } TestStruct;
 
-TestStruct global_struct;
+static TestStruct global_struct = {.first_uint32 = 0, .second_uint32 = 0};
 
 static TestStruct *getGlobalStruct(void) {
   return &global_struct;


### PR DESCRIPTION
This PR does 3 things:
- enables the `-O2` optimization flags on binaries intended for decompilation tests. We want those to be optimized because we want the decompiler to give good results on high optimization levels.
- avoid calling `malloc` to work around some current limitations/bugs of `revng`, without affecting the quality of the decompilation test
- adds some accessors to the linked list test, to allow for more interesting results in decompilation.