### PR TITLE
Minor improvements for `revng-test-configure` script

### DIFF
--- a/revng-test-configure
+++ b/revng-test-configure
@@ -59,8 +59,9 @@ def most_similar_tuples(inputs):
     if len(inputs) == 1:
         return list(product(*inputs))
 
-    result = []
+    fully_compatible = []
 
+    most_similar = []
     maximum_similarity = 0
 
     # Get the most similar set of tuples, i.e., those that share the most
@@ -79,15 +80,26 @@ def most_similar_tuples(inputs):
 
         if similarity > maximum_similarity:
             maximum_similarity = similarity
-            result = []
+            most_similar = []
 
         if similarity == maximum_similarity:
-            result.append(candidate_set)
+            most_similar.append(candidate_set)
+
+        for candidate in candidate_set:
+            if candidate in common_targets:
+                fully_compatible.append(candidate_set)
+                break
+
+    # For now, discard the `most_similar` list in case there are any perfect
+    # matches (perfect match is when all the inputs in the current candidate set
+    # derive from a single input present in the same set)
+    # TODO: consider if we still want to keep it.
+    selected = fully_compatible if len(fully_compatible) != 0 else most_similar
 
     # Further refine based on common tags
     maximum_similarity = 0
-    result2 = []
-    for candidate_set in result:
+    result = []
+    for candidate_set in selected:
         candidate_tags = [set(candidate.tags)
                           for candidate
                           in candidate_set]
@@ -98,12 +110,12 @@ def most_similar_tuples(inputs):
 
         if similarity > maximum_similarity:
             maximum_similarity = similarity
-            result2 = []
+            result = []
 
         if similarity == maximum_similarity:
-            result2.append(candidate_set)
+            result.append(candidate_set)
 
-    return result2
+    return result
 
 def sort_list(entries, key, dependencies):
     # Collect entries by key and id

--- a/revng-test-configure
+++ b/revng-test-configure
@@ -98,7 +98,8 @@ def most_similar_tuples(inputs):
 
     # Further refine based on common tags
     maximum_similarity = 0
-    result = []
+    most_similar = []
+    fully_compatible = []
     for candidate_set in selected:
         candidate_tags = [set(candidate.tags)
                           for candidate
@@ -110,12 +111,21 @@ def most_similar_tuples(inputs):
 
         if similarity > maximum_similarity:
             maximum_similarity = similarity
-            result = []
+            most_similar = []
 
         if similarity == maximum_similarity:
-            result.append(candidate_set)
+            most_similar.append(candidate_set)
 
-    return result
+        is_fully_compatible = True
+        for candidate in candidate_set:
+            if (set(candidate.tags) != common_tags):
+                is_fully_compatible = False
+                break
+
+        if is_fully_compatible:
+            fully_compatible.append(candidate_set)
+
+    return fully_compatible if len(fully_compatible) != 0 else most_similar
 
 def sort_list(entries, key, dependencies):
     # Collect entries by key and id

--- a/revng-test-configure
+++ b/revng-test-configure
@@ -417,10 +417,10 @@ class Configuration:
                        command_name,
                        command_type,
                        command_suffix):
-        final_tags = list(output_tags)
+        final_tags = set(output_tags)
         for target in input_targets:
             for input_tag in target.tags:
-                final_tags.append(input_tag)
+                final_tags.add(input_tag)
 
         # OK, we have all the inputs
         derived_targets_prefix = input_targets[0].derived_targets_prefix
@@ -438,7 +438,7 @@ class Configuration:
 
         new_target = Target(name=command_name,
                             type=command_type,
-                            tags=final_tags,
+                            tags=list(final_tags),
                             path=path,
                             source_path=input_targets[0].source_path,
                             derived_targets_prefix=derived_targets_prefix,
@@ -447,10 +447,6 @@ class Configuration:
 
         # Initialize variables
         variables = new_target.variables
-
-        for target in input_targets:
-            for tag in target.tags:
-                variables.merge(tag.variables)
 
         for tag in final_tags:
             variables.merge(tag.variables)


### PR DESCRIPTION
This is a sister PR for https://github.com/revng/revng/pull/274

The similarity is defined as the length of the common chain of the steps taken from the source.
But, when comparing two tuples, the choice made on that characteristic alone is not sufficient for the cases where one of the inputs is a derivatives of another: in this case the full "path" to the shorter step is given.

The problem arrives if the total "path" lengths for multiple desired test cases do not match, for example, `compiled-with-debug-info` started chain is always one step shorter than the one that goes through `compiled-stripped`. As such, when doing a basic filter on two derived inputs, no test with `debug-info` will ever be run.

The second problem with tags is exactly the same. `native-dynamic` test case is always one tag shorter compared to `static` cases with given architectures, so, similarly, when multiple inputs overlap, the `dynamic` test cases never make it thorough.

P. S. There's also a minor fix pushing all the tags and variables through a `set` when merging them - to avoid duplication.