### PR TITLE
Add various tests for decompilation

### DIFF
--- a/share/revng/test/configuration/revng-qa/compile.yml
+++ b/share/revng/test/configuration/revng-qa/compile.yml
@@ -1,6 +1,5 @@
 tags:
   - name: simple-executable
-
   - name: stripped
   - name: with-debug-info
 commands:

--- a/share/revng/test/configuration/revng-qa/for-data-layout-analysis.yml
+++ b/share/revng/test/configuration/revng-qa/for-data-layout-analysis.yml
@@ -1,0 +1,21 @@
+tags:
+  - name: for-data-layout-analysis
+    variables:
+      CFLAGS:
+        - -O2
+        - -Wno-pointer-bool-conversion
+        - -fno-unroll-loops
+        - -fno-inline
+        - -fno-optimize-sibling-calls
+        - -fno-stack-protector
+sources:
+  - tags: [for-data-layout-analysis]
+    members:
+      - share/revng/test/tests/analysis/data-layout-analysis/linked-lists.c
+      - share/revng/test/tests/analysis/data-layout-analysis/segments-and-sections.c
+commands:
+  - type: revng-qa.compiled-for-data-layout-analysis
+    from:
+      - type: source
+        filter: for-data-layout-analysis
+    command: clang $INPUT -o $OUTPUT $CFLAGS

--- a/share/revng/test/configuration/revng-qa/for-pretty-int-formatting.yml
+++ b/share/revng/test/configuration/revng-qa/for-pretty-int-formatting.yml
@@ -1,0 +1,19 @@
+tags:
+  - name: for-pretty-int-formatting
+    variables:
+      CFLAGS:
+        - -O2
+        - -fno-inline
+        - -fno-optimize-sibling-calls
+        - -fno-stack-protector
+sources:
+  - tags: [for-pretty-int-formatting]
+    members:
+      - share/revng/test/tests/analysis/pretty-int-formatting/pretty-ints.c
+commands:
+  - type: revng-qa.compiled-for-pretty-int-formatting
+    from:
+      - type: source
+        filter: for-pretty-int-formatting
+    command: clang $INPUT -o $OUTPUT $CFLAGS
+

--- a/share/revng/test/tests/analysis/data-layout-analysis/linked-lists.c
+++ b/share/revng/test/tests/analysis/data-layout-analysis/linked-lists.c
@@ -1,0 +1,41 @@
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#define DATA_LEN 5
+
+struct node {
+  int64_t data[DATA_LEN];
+  struct node *next;
+};
+
+__attribute__((weak)) struct node *init_list() {
+  return NULL;
+}
+
+__attribute__((weak)) void release_list(struct node *n) {
+  free(n);
+}
+
+__attribute__((weak)) int64_t sum(struct node *n) {
+  int64_t result = 0;
+  for (int i = 0; i < DATA_LEN; ++i)
+    result += n->data[i];
+  return result;
+}
+
+__attribute__((weak)) int64_t compute(struct node *n __attribute__((nonnull))) {
+  int64_t result = 0;
+  while (n) {
+    result += sum(n);
+    n = n->next;
+  }
+  return result;
+}
+
+int main() {
+  struct node *head = init_list();
+  int64_t result = compute(head);
+  release_list(head);
+  return result != 42;
+}

--- a/share/revng/test/tests/analysis/data-layout-analysis/segments-and-sections.c
+++ b/share/revng/test/tests/analysis/data-layout-analysis/segments-and-sections.c
@@ -1,3 +1,5 @@
+#include <stdio.h>
+
 __attribute__((weak)) struct {
   int x;
   char padding[1000];
@@ -8,6 +10,12 @@ __attribute__((weak)) struct {
   .y = 12,
 };
 
+__attribute__((weak))
+void print_string() {
+  puts("hello world!");
+}
+
 int main() {
+  print_string();
   return TheData.x + TheData.y;
 }

--- a/share/revng/test/tests/analysis/data-layout-analysis/segments-and-sections.c
+++ b/share/revng/test/tests/analysis/data-layout-analysis/segments-and-sections.c
@@ -1,0 +1,13 @@
+__attribute__((weak)) struct {
+  int x;
+  char padding[1000];
+  int y;
+} TheData = {
+  .x = 7,
+  .padding = { 0 },
+  .y = 12,
+};
+
+int main() {
+  return TheData.x + TheData.y;
+}

--- a/share/revng/test/tests/analysis/pretty-int-formatting/pretty-ints.c
+++ b/share/revng/test/tests/analysis/pretty-int-formatting/pretty-ints.c
@@ -1,0 +1,54 @@
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+__attribute__((weak))
+uint64_t shift_left(int64_t amount) {
+  return 0xABCDEF1234567890ULL << amount;
+}
+
+__attribute__((weak))
+uint64_t logical_shift_right(int64_t amount) {
+  return 0xABCDEF1234567890ULL >> amount;
+}
+
+__attribute__((weak))
+int64_t arithmetic_shift_right(int64_t amount) {
+  return 0xABCDEF1234567890LL >> amount;
+}
+
+__attribute__((weak))
+uint64_t bitwise_and(int64_t arg) {
+  return 0xABCDEF1234567890ULL & arg;
+}
+
+__attribute__((weak))
+uint64_t bitwise_or(int64_t arg) {
+  return 0xABCDEF1234567890ULL | arg;
+}
+
+__attribute__((weak))
+uint64_t bitwise_xor(int64_t arg) {
+  return 0xABCDEF1234567890ULL ^ arg;
+}
+
+__attribute__((weak))
+int8_t data;
+
+__attribute__((weak))
+int8_t write_and_get_char() {
+  return data = 'X';
+}
+
+int main(int argc, const char **argv) {
+  puts(NULL);
+  return shift_left(argc)
+    + logical_shift_right(argc)
+    + arithmetic_shift_right(argc)
+    + bitwise_or(argc)
+    + bitwise_and(argc)
+    + bitwise_xor(argc)
+    + write_and_get_char();
+}


### PR DESCRIPTION
This patchset adds tests for various features of the decompiler:
- DLA capability to recover complex data structure like linked-lists and arrays
- DLA capability to update segment and section types, so that we emit nice looking accesses to segments in C
- Capability to emit nice looking integer literals in C
- Capability to emit inline string literals in C

All the actual tests are implmented in `revng-c`, based on `FileCheck`. Here we're adding only the original source, and recipes to compile the code to generated the binaries that are then used in `revng-c` for tests.